### PR TITLE
Disable time format

### DIFF
--- a/forms/kontajneroveStojiska/form.fo.xslt
+++ b/forms/kontajneroveStojiska/form.fo.xslt
@@ -194,10 +194,10 @@
     <xsl:value-of select="concat($dd,'.',$mm,'.',$yyyy)"/>
   </xsl:template>
 
-  <xsl:template name="base_format_time">
+  <!-- <xsl:template name="base_format_time">
     <xsl:param name="instr"/>
     <xsl:value-of select="format-time($instr, '[H01]:[m01]')"/>
-  </xsl:template>
+  </xsl:template> -->
 
   <xsl:template name="base_format_datetime">
     <xsl:param name="dateTime"/>

--- a/forms/kontajneroveStojiska/form.html.xslt
+++ b/forms/kontajneroveStojiska/form.html.xslt
@@ -203,10 +203,10 @@
     <xsl:value-of select="concat($dd,'.',$mm,'.',$yyyy)"/>
   </xsl:template>
 
-  <xsl:template name="base_format_time">
+  <!-- <xsl:template name="base_format_time">
     <xsl:param name="instr"/>
     <xsl:value-of select="format-time($instr, '[H01]:[m01]')"/>
-  </xsl:template>
+  </xsl:template> -->
 
   <xsl:template name="base_format_datetime">
     <xsl:param name="dateTime"/>

--- a/forms/kontajneroveStojiska/form.sb.xslt
+++ b/forms/kontajneroveStojiska/form.sb.xslt
@@ -170,10 +170,10 @@
     <xsl:value-of select="concat($dd,'.',$mm,'.',$yyyy)"/>
   </xsl:template>
 
-  <xsl:template name="base_format_time">
+  <!-- <xsl:template name="base_format_time">
     <xsl:param name="instr"/>
     <xsl:value-of select="format-time($instr, '[H01]:[m01]')"/>
-  </xsl:template>
+  </xsl:template> -->
 
   <xsl:template name="base_format_datetime">
     <xsl:param name="dateTime"/>

--- a/src/core/forms.ts
+++ b/src/core/forms.ts
@@ -74,8 +74,9 @@ const getJsonSchemaFormat = (type: string | undefined): JsonSchemaFormat => {
   switch (type) {
     case 'xs:date':
       return 'date'
-    case 'xs:time':
-      return 'time'
+    // disabled until we figure out how to make it work with https://github.com/bratislava/sk-bratislava-fop
+    // case 'xs:time':
+    //   return 'time'
     case 'xs:dateTime':
       return 'date-time'
     case 'EmailType':
@@ -258,8 +259,9 @@ const getXsdTypeByFormat = (format: JsonSchemaFormat): XsdType => {
   switch (format) {
     case 'date':
       return 'xs:date'
-    case 'time':
-      return 'xs:time'
+    // disabled until we figure out how to make it work with https://github.com/bratislava/sk-bratislava-fop
+    // case 'time':
+    //   return 'xs:time'
     case 'date-time':
       return 'xs:dateTime'
     case 'email':

--- a/src/core/xslt.ts
+++ b/src/core/xslt.ts
@@ -12,8 +12,6 @@ const buildNode = (el: string, type: JsonSchemaType, format: JsonSchemaFormat): 
   if (type === 'string') {
     if (format === 'date') {
       return `<xsl:with-param name="node"><xsl:call-template name="base_format_date"><xsl:with-param name="instr" select="$values/z:${el}" /></xsl:call-template></xsl:with-param>`
-    } else if (format === 'time') {
-      return `<xsl:with-param name="node"><xsl:call-template name="base_format_time"><xsl:with-param name="time" select="$values/z:${el}" /></xsl:call-template></xsl:with-param>`
     } else if (format === 'date-time') {
       return `<xsl:with-param name="node"><xsl:call-template name="base_format_datetime"><xsl:with-param name="dateTime" select="$values/z:${el}" /></xsl:call-template></xsl:with-param>`
     } else if (format === 'ciselnik') {
@@ -21,6 +19,9 @@ const buildNode = (el: string, type: JsonSchemaType, format: JsonSchemaFormat): 
     } else if (format === 'file') {
       return `<xsl:with-param name="node" select="$values/z:${el}/z:Nazov" />`
     }
+    // disabled until we figure out how to make it work with https://github.com/bratislava/sk-bratislava-fop
+    // } else if (format === 'time') {
+    //   return `<xsl:with-param name="node"><xsl:call-template name="base_format_time"><xsl:with-param name="time" select="$values/z:${el}" /></xsl:call-template></xsl:with-param>`
   } else if (type === 'boolean') {
     return `<xsl:with-param name="node"><xsl:call-template name="base_boolean"><xsl:with-param name="bool" select="$values/z:${el}" /></xsl:call-template></xsl:with-param>`
   }

--- a/src/templates/template.fo.xslt.js
+++ b/src/templates/template.fo.xslt.js
@@ -132,10 +132,10 @@ export default `<?xml version="1.0" encoding="utf-8"?>
     <xsl:value-of select="concat($dd,'.',$mm,'.',$yyyy)"/>
   </xsl:template>
 
-  <xsl:template name="base_format_time">
+  <!-- <xsl:template name="base_format_time">
     <xsl:param name="instr"/>
     <xsl:value-of select="format-time($instr, '[H01]:[m01]')"/>
-  </xsl:template>
+  </xsl:template> -->
 
   <xsl:template name="base_format_datetime">
     <xsl:param name="dateTime"/>

--- a/src/templates/template.html.xslt.js
+++ b/src/templates/template.html.xslt.js
@@ -135,10 +135,10 @@ export default `<?xml version="1.0" encoding="utf-8" standalone="yes"?>
     <xsl:value-of select="concat($dd,'.',$mm,'.',$yyyy)"/>
   </xsl:template>
 
-  <xsl:template name="base_format_time">
+  <!-- <xsl:template name="base_format_time">
     <xsl:param name="instr"/>
     <xsl:value-of select="format-time($instr, '[H01]:[m01]')"/>
-  </xsl:template>
+  </xsl:template> -->
 
   <xsl:template name="base_format_datetime">
     <xsl:param name="dateTime"/>

--- a/src/templates/template.sb.xslt.js
+++ b/src/templates/template.sb.xslt.js
@@ -101,10 +101,10 @@ export default `<?xml version="1.0" encoding="utf-8" standalone="yes"?>
     <xsl:value-of select="concat($dd,'.',$mm,'.',$yyyy)"/>
   </xsl:template>
 
-  <xsl:template name="base_format_time">
+  <!-- <xsl:template name="base_format_time">
     <xsl:param name="instr"/>
     <xsl:value-of select="format-time($instr, '[H01]:[m01]')"/>
-  </xsl:template>
+  </xsl:template> -->
 
   <xsl:template name="base_format_datetime">
     <xsl:param name="dateTime"/>


### PR DESCRIPTION
@radeno unfortunately [our instance](https://github.com/bratislava/sk-bratislava-fop) of [Apache FOP](https://xmlgraphics.apache.org/fop/) which we're using to do the pdf transform itself does not understand the format-time 'directive' (the error is `Could not find function: format-time`).

The config of this instance probably leaves much to be desired, so it's quite possible we just need to add something in there https://github.com/bratislava/sk-bratislava-fop - unfortunately I do not understand it well enough to know how to fix this quickly, so until then, I've reverted for time format to be processed as a regular string. 

We'll need to work on the FOP config in following days as it does not process anything besides the most basic forms yet, might fix it as part of it.

We'll also want consider adding a test suite calling the fop transform to this repo - likely a larger question together with making the current tests always run with up to date forms from the [account frontend repo](https://github.com/bratislava/konto.bratislava.sk).