### PR TITLE
Fix invalid character in email type

### DIFF
--- a/forms/00603481.dopravneZnacenie.sk/schema.generated.xsd
+++ b/forms/00603481.dopravneZnacenie.sk/schema.generated.xsd
@@ -29,7 +29,7 @@
 
   <xs:simpleType name="EmailType">
     <xs:restriction base="xs:string">
-        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z-￿]{2,}"/>
+        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/forms/00603481.dopravneZnacenie.sk/schema.xsd
+++ b/forms/00603481.dopravneZnacenie.sk/schema.xsd
@@ -243,7 +243,7 @@
       <xs:element name="MestskaCast" type="MestskaCastEnumType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="FaxPreDorucenie" type="TelefonneCisloType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="TelefonPreDorucenie" type="TelefonneCisloType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="EmailPreDorucenie" type="EMailType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="EmailPreDorucenie" type="EmailType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -378,7 +378,7 @@
     <xs:sequence>
       <xs:element name="TelefonneCislo" type="TelefonneCisloType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="TelefonneCisloCele" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="Email" type="EMailType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Email" type="EmailType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="KontaktnaOsoba" type="KontaktnaOsobaType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
@@ -440,7 +440,7 @@
     </xs:sequence>
   </xs:complexType>
 
-  <xs:simpleType name="EMailType">
+  <xs:simpleType name="EmailType">
     <xs:restriction base="xs:string">
       <xs:pattern
               value="([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,6}|[0-9]{1,3})(\]?)"/>

--- a/forms/allOf/schema.xsd
+++ b/forms/allOf/schema.xsd
@@ -29,7 +29,7 @@
 
   <xs:simpleType name="EmailType">
     <xs:restriction base="xs:string">
-        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z-￿]{2,}"/>
+        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/forms/kontajneroveStojiska/schema.xsd
+++ b/forms/kontajneroveStojiska/schema.xsd
@@ -29,7 +29,7 @@
 
   <xs:simpleType name="EmailType">
     <xs:restriction base="xs:string">
-        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z-￿]{2,}"/>
+        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/forms/test/schema.xsd
+++ b/forms/test/schema.xsd
@@ -29,7 +29,7 @@
 
   <xs:simpleType name="EmailType">
     <xs:restriction base="xs:string">
-        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z-￿]{2,}"/>
+        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,}"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bratislava/jsxt",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "",
   "main": "dist/jsxt.js",
   "files": [

--- a/src/templates/template.xsd.js
+++ b/src/templates/template.xsd.js
@@ -30,7 +30,7 @@ export default `<?xml version="1.0" encoding="utf-8"?>
 
   <xs:simpleType name="EmailType">
     <xs:restriction base="xs:string">
-        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z\u0080-\uFFFF]{2,}"/>
+        <xs:pattern value="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
The unicode character used was not valid and caused NASES to reject forms without error. Fyi @radeno .